### PR TITLE
Add first line for client components

### DIFF
--- a/app/hubs-base/[hub]/page.tsx
+++ b/app/hubs-base/[hub]/page.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Button } from "@/components/ui/button";
 import { Star } from "lucide-react";
 import Image from "next/image";

--- a/components/hub/hub-card.tsx
+++ b/components/hub/hub-card.tsx
@@ -3,7 +3,6 @@ import { Button } from "@/components/ui/button";
 import { Star } from "lucide-react";
 import Image from "next/image";
 import { HubAlert } from "./hub-alert";
-import { useState } from "react";
 import { Profile } from "../component/profile";
 
 const stars = [1, 2, 3, 4, 5];


### PR DESCRIPTION
Some components uses hooks like useState, so those should be cliente, we 
should established those as client components with 'use client' in the first
line of each client component
